### PR TITLE
show sbox supported runtime

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1660,7 +1660,7 @@ var shellCmd = &cobra.Command{
 			},
 		}
 
-		supportRuntimes := map[string]string{
+		supportedRuntimes := map[string]string{
 			"python2.7": "aliyunfc/runtime-python2.7:build",
 			"python3":   "aliyunfc/runtime-python3.6:build",
 			"nodejs6":   "aliyunfc/runtime-nodejs6:build",
@@ -1671,7 +1671,7 @@ var shellCmd = &cobra.Command{
 
 		getDockerCmdString := func(runtime string, codeDir string) (string, error) {
 
-			if v, ok := supportRuntimes[runtime]; ok {
+			if v, ok := supportedRuntimes[runtime]; ok {
 				return fmt.Sprintf(dockerRunFormat, codeDir, v), nil
 			}
 			return "", fmt.Errorf("invalid runtime: %s", runtime)
@@ -1687,8 +1687,8 @@ var shellCmd = &cobra.Command{
 				help := flags.Bool("help", false, "")
 				codeDir := flags.StringP("code-dir", "d", "", "the code directory")
 
-				supportedRuntimeKeys := make([]string, 0, len(supportRuntimes))
-				for k := range supportRuntimes {
+				supportedRuntimeKeys := make([]string, 0, len(supportedRuntimes))
+				for k := range supportedRuntimes {
 					supportedRuntimeKeys = append(supportedRuntimeKeys, k)
 				}
 				runtimeSupportStr := strings.Join(supportedRuntimeKeys, ", ")

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1660,15 +1660,17 @@ var shellCmd = &cobra.Command{
 			},
 		}
 
+		supportRuntimes := map[string]string{
+			"python2.7": "aliyunfc/runtime-python2.7:build",
+			"python3":   "aliyunfc/runtime-python3.6:build",
+			"nodejs6":   "aliyunfc/runtime-nodejs6:build",
+			"nodejs8":   "aliyunfc/runtime-nodejs8:build",
+			"java8":     "aliyunfc/runtime-java8:build",
+			"php7.2":    "aliyunfc/runtime-php7.2:build",
+		}
+
 		getDockerCmdString := func(runtime string, codeDir string) (string, error) {
-			supportRuntimes := map[string]string{
-				"python2.7": "aliyunfc/runtime-python2.7:build",
-				"python3":   "aliyunfc/runtime-python3.6:build",
-				"nodejs6":   "aliyunfc/runtime-nodejs6:build",
-				"nodejs8":   "aliyunfc/runtime-nodejs8:build",
-				"java8":     "aliyunfc/runtime-java8:build",
-				"php7.2":    "aliyunfc/runtime-php7.2:build",
-			}
+
 			if v, ok := supportRuntimes[runtime]; ok {
 				return fmt.Sprintf(dockerRunFormat, codeDir, v), nil
 			}
@@ -1684,7 +1686,14 @@ var shellCmd = &cobra.Command{
 				flags := pflag.NewFlagSet("config", pflag.ContinueOnError)
 				help := flags.Bool("help", false, "")
 				codeDir := flags.StringP("code-dir", "d", "", "the code directory")
-				runtime := flags.StringP("runtime", "t", "", "the function compute runtime")
+
+				runtimeSupportKeys := make([]string, 0, len(supportRuntimes))
+				for k := range supportRuntimes {
+					runtimeSupportKeys = append(runtimeSupportKeys, k)
+				}
+				runtimeSupportStr := strings.Join(runtimeSupportKeys, ", ")
+
+				runtime := flags.StringP("runtime", "t", "", "supported runtime value:  "+runtimeSupportStr)
 				err := flags.Parse(c.Args)
 				if err != nil {
 					c.Err(err)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1693,7 +1693,7 @@ var shellCmd = &cobra.Command{
 				}
 				runtimeSupportStr := strings.Join(runtimeSupportKeys, ", ")
 
-				runtime := flags.StringP("runtime", "t", "", "supported runtime value:  "+runtimeSupportStr)
+				runtime := flags.StringP("runtime", "t", "", "supported runtimes :  "+runtimeSupportStr)
 				err := flags.Parse(c.Args)
 				if err != nil {
 					c.Err(err)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1691,9 +1691,8 @@ var shellCmd = &cobra.Command{
 				for k := range supportedRuntimes {
 					supportedRuntimeKeys = append(supportedRuntimeKeys, k)
 				}
-				supportedRuntimeStr := strings.Join(supportedRuntimeKeys, ", ")
 
-				runtime := flags.StringP("runtime", "t", "", "supported runtimes :  "+supportedRuntimeStr)
+				runtime := flags.StringP("runtime", "t", "", "supported runtimes :  "+strings.Join(supportedRuntimeKeys, ", "))
 				err := flags.Parse(c.Args)
 				if err != nil {
 					c.Err(err)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1687,11 +1687,11 @@ var shellCmd = &cobra.Command{
 				help := flags.Bool("help", false, "")
 				codeDir := flags.StringP("code-dir", "d", "", "the code directory")
 
-				runtimeSupportKeys := make([]string, 0, len(supportRuntimes))
+				supportedRuntimeKeys := make([]string, 0, len(supportRuntimes))
 				for k := range supportRuntimes {
-					runtimeSupportKeys = append(runtimeSupportKeys, k)
+					supportedRuntimeKeys = append(supportedRuntimeKeys, k)
 				}
-				runtimeSupportStr := strings.Join(runtimeSupportKeys, ", ")
+				runtimeSupportStr := strings.Join(supportedRuntimeKeys, ", ")
 
 				runtime := flags.StringP("runtime", "t", "", "supported runtimes :  "+runtimeSupportStr)
 				err := flags.Parse(c.Args)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1691,9 +1691,9 @@ var shellCmd = &cobra.Command{
 				for k := range supportedRuntimes {
 					supportedRuntimeKeys = append(supportedRuntimeKeys, k)
 				}
-				runtimeSupportStr := strings.Join(supportedRuntimeKeys, ", ")
+				supportedRuntimeStr := strings.Join(supportedRuntimeKeys, ", ")
 
-				runtime := flags.StringP("runtime", "t", "", "supported runtimes :  "+runtimeSupportStr)
+				runtime := flags.StringP("runtime", "t", "", "supported runtimes :  "+supportedRuntimeStr)
 				err := flags.Parse(c.Args)
 				if err != nil {
 					c.Err(err)


### PR DESCRIPTION
增加列出 sbox 所有的 runtime 的功能
```
>>> sbox --help
sbox: A sandbox environment for installing the 3rd party libararies and trouble shooting. It's consistent with the function execution environment in FunctionCompute service. You should install dependent libraries or test your function in the sandbox to prenvent from any environment issues.
note: the sbox feature requires docker is availabe on your machine.
usage: sbox [flags]
       type "exit" to exit the sandbox.
flags:
  -d, --code-dir string   the code directory
      --help
  -t, --runtime string    supported runtimes :  nodejs6, nodejs8, java8, php7.2, python2.7, python3

```