### PR TITLE
Added support for custom-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ $ go install github.com/Masterminds/glide
 __4. 安装依赖__
 在项目根目录下，执行 `glide i -v` 进行依赖安装
 
+__5. 构建 fcli 二进制__
+```
+$ go get github.com/karalabe/xgo
+$ make binary
+```
+
 ### 提交 pull request
 
 __1. 将修改 push 到个人账号里的本地仓库__

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ccfa479ad08397e433d854e0841acee9f32271f1e5e3abf544111c7f2266e183
-updated: 2019-03-26T11:41:17.279774+08:00
+hash: 161954f2f5a530914e7633d14d2a93520e6695a4cbd55db48cf7deaffe8de048
+updated: 2020-08-21T02:25:19.046912557-07:00
 imports:
 - name: github.com/abiosoft/ishell
   version: 8b8aa74a85127192b469453a72fd7971b47481fb
@@ -8,7 +8,7 @@ imports:
 - name: github.com/aliyun/aliyun-log-go-sdk
   version: 0402edd803e987675a1f88f1cb80bfa006e7e28e
 - name: github.com/aliyun/fc-go-sdk
-  version: db3e654c23d6c7ce8f61bd75b70f77dec9142cda
+  version: 0882be48e49f6c9682da173b4121d72db92924c5
 - name: github.com/alyu/configparser
   version: c505e6011694d3c8c1accccea3c9f57eef22afb1
 - name: github.com/denisbrodbeck/machineid
@@ -95,12 +95,12 @@ imports:
   - transform
   - unicode/norm
 - name: gopkg.in/AlecAivazis/survey.v1
-  version: ee72c28b95a5ff3e227cfd403f556f0ef4b07ca5
+  version: da50ccef2fd74048e26b7846a731da4254035115
   subpackages:
   - core
   - terminal
 - name: gopkg.in/h2non/gock.v1
-  version: ba88c4862a27596539531ce469478a91bc5a0511
+  version: 3ffff9b1aa8200275a5eb219c5f9c62bd27acb31
 - name: gopkg.in/matryer/try.v1
   version: 312d2599e12e89ca89b52a09597394f449235d80
 - name: gopkg.in/resty.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,6 +1,7 @@
 package: github.com/aliyun/fcli
 import:
 - package: github.com/aliyun/fc-go-sdk
+  version: 0882be48e49f6c9682da173b4121d72db92924c5
 - package: github.com/alyu/configparser
 - package: github.com/spf13/cobra
 - package: gopkg.in/matryer/try.v1
@@ -9,7 +10,7 @@ import:
 - package: github.com/abiosoft/ishell
 - package: gopkg.in/yaml.v2
 - package: github.com/aliyun/aliyun-log-go-sdk
-  version: ^0.1.0
+  version: 0402edd803e987675a1f88f1cb80bfa006e7e28e
 - package: gopkg.in/AlecAivazis/survey.v1
   version: ^1.6.3
 - package: github.com/denisbrodbeck/machineid

--- a/util/util.go
+++ b/util/util.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/aliyun/fcli/version"
 
-	"github.com/aliyun/aliyun-log-go-sdk"
+	sls "github.com/aliyun/aliyun-log-go-sdk"
 	"github.com/denisbrodbeck/machineid"
 	"github.com/spf13/viper"
 
@@ -52,6 +52,9 @@ const (
 
 	// KeyValueDelimiter defines key value delimiter of map params
 	KeyValueDelimiter = "="
+
+	// RuntimeCustomContainer const for custom-container runtime
+	RuntimeCustomContainer = "custom-container"
 )
 
 // GlobalConfig define the global configurations.


### PR DESCRIPTION

```
US-133320M1:fcli shuai.chang$ ./bundles/fcli-darwin-10.6-amd64 function create --help
Create function

Usage:
  fcli function create [flags]

Aliases:
  create, c

Flags:
      --ca-port int32                     args of custom container config
  -b, --code-bucket string                oss bucket of the code
  -d, --code-dir string                   function code directory. If both code-file and code-dir are provided, code-file will be used.
      --code-file string                  zipped code file. If both code-file and code-dir are provided, code-file will be used.
  -o, --code-object string                oss object of the code
  -r, --custom-container-args string      custom container config args, e.g. ["server.js"]
  -n, --custom-container-command string   custom container config command, e.g. ["node"]
  -g, --custom-container-image string     custom container config image
      --description string                brief description
      --env stringArray                   set environment variables. e.g. --env VAR1=val1 --env VAR2=val2
      --env-file stringArray              read in a file of environment variables. e.g. --env-file FILE1 --env-file FILE2
  -f, --function-name string              the function name
  -h, --handler string                    handler is the entrypoint for the function execution
      --help                              
  -e, --initializationTimeout int32       timeout in seconds (default 30)
  -i, --initializer string                initializer is the entrypoint for the initializer execution
  -m, --memory int32                      memory size in MB (default 128)
  -t, --runtime string                    function runtime
  -s, --service-name string               the service name
      --timeout int32                     timeout in seconds (default 30)
US-133320M1:fcli shuai.chang$ ./bundles/fcli-darwin-10.6-amd64 function update --help
Update function attributes

Usage:
  fcli function update [option] [flags]

Aliases:
  update, u

Flags:
  -b, --bucket string                     oss code bucket
      --ca-port int32                     args of custom container config (default 9000)
      --code-dir string                   function code directory. If both code-file and code-dir are provided, code-file will be used.
      --code-file string                  zipped code file. If both code-file and code-dir are provided, code-file will be used.
  -r, --custom-container-args string      custom container config args, e.g. ["server.js"]
  -n, --custom-container-command string   custom container config command, e.g. ["node"]
  -g, --custom-container-image string     custom container config image
  -d, --description string                function description
      --env stringArray                   set environment variables. e.g. --env VAR1=val1 --env VAR2=val2
      --env-file stringArray              read in a file of environment variables. e.g. --env-file FILE1 --env-file FILE2
      --etag string                       provide etag to do the conditional update. If the specified etag does not match the function's, the update will fail.
  -f, --function-name string              the function name
  -h, --handler string                    function handler
      --help                              Print Usage
  -e, --initializationTimeout int32       initializer timeout in seconds
  -i, --initializer string                function initializer
  -o, --object string                     oss code object
  -t, --runtime string                    function runtime
  -s, --service-name string               the service name
      --timeout int32                     function timeout in seconds
```


```
./bundles/fcli-darwin-10.6-amd64 function create -s CustomContainerDemo -f nodejs-express-http-fcli --ca-port 8080 --runtime custom-container --handler bootstrap --custom-container-image registry-vpc.cn-shenzhen.aliyuncs.com/fc-demo/nodejs-express:v0.3
```

```
./bundles/fcli-darwin-10.6-amd64 function update -s CustomContainerDemo -f nodejs-express-http-fcli --ca-port 8080 --runtime custom-container --handler bootstrap --custom-container-image registry-vpc.cn-shenzhen.aliyuncs.com/fc-demo/nodejs-express:v0.3
```
